### PR TITLE
Add a service to process news articles and generate confidence score

### DIFF
--- a/ipno/data/services/article_classification_importer.py
+++ b/ipno/data/services/article_classification_importer.py
@@ -4,6 +4,7 @@ from data.constants import NEWS_ARTICLE_CLASSIFICATION_MODEL_NAME
 from data.services.base_importer import BaseImporter
 from data.services.data_reconciliation import DataReconciliation
 from news_articles.models import NewsArticle, NewsArticleClassification
+from news_articles.services.openai_llm_service import OpenAILLMService
 
 
 class ArticleClassificationImporter(BaseImporter):  # pragma: no cover
@@ -34,6 +35,8 @@ class ArticleClassificationImporter(BaseImporter):  # pragma: no cover
             NEWS_ARTICLE_CLASSIFICATION_MODEL_NAME, csv_file_path
         )
 
+        self.openai_service = OpenAILLMService(api_key="your_openai_api_key")
+
     def handle_record_data(self, row):
         article_classification_data = self.parse_row_data(row, self.column_mappings)
 
@@ -42,6 +45,11 @@ class ArticleClassificationImporter(BaseImporter):  # pragma: no cover
 
         article_classification_id = self.article_classification_mappings.get(article_id)
         article_classification_data["news_article_id"] = relation_article_id
+
+        # Call OpenAI LLM service to get confidence score
+        article_text = article_classification_data.get("text", "")
+        confidence_score = self.openai_service.get_confidence_score(article_text)
+        article_classification_data["confidence_score"] = confidence_score
 
         if article_classification_id:
             article_classification_data["id"] = article_classification_id

--- a/ipno/news_articles/services/openai_llm_service.py
+++ b/ipno/news_articles/services/openai_llm_service.py
@@ -1,0 +1,23 @@
+import openai
+import logging
+
+class OpenAILLMService:
+    def __init__(self, api_key):
+        self.api_key = api_key
+        openai.api_key = self.api_key
+
+    def get_confidence_score(self, article_text):
+        try:
+            response = openai.Completion.create(
+                engine="gpt-4",
+                prompt=f"Does the text of this article contain any reference to police misconduct? {article_text}",
+                max_tokens=1,
+                n=1,
+                stop=None,
+                temperature=0.5,
+            )
+            score = response.choices[0].text.strip()
+            return float(score)
+        except Exception as e:
+            logging.error(f"Error while calling OpenAI API: {e}")
+            return None

--- a/ipno/news_articles/tests/services/test_openai_llm_service.py
+++ b/ipno/news_articles/tests/services/test_openai_llm_service.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from news_articles.services.openai_llm_service import OpenAILLMService
+
+class TestOpenAILLMService(unittest.TestCase):
+    def setUp(self):
+        self.api_key = "test_api_key"
+        self.service = OpenAILLMService(api_key=self.api_key)
+
+    @patch("news_articles.services.openai_llm_service.openai.Completion.create")
+    def test_get_confidence_score(self, mock_create):
+        mock_response = MagicMock()
+        mock_response.choices[0].text.strip.return_value = "0.85"
+        mock_create.return_value = mock_response
+
+        article_text = "This is a test article text."
+        score = self.service.get_confidence_score(article_text)
+
+        self.assertEqual(score, 0.85)
+        mock_create.assert_called_once_with(
+            engine="gpt-4",
+            prompt="Does the text of this article contain any reference to police misconduct? This is a test article text.",
+            max_tokens=1,
+            n=1,
+            stop=None,
+            temperature=0.5,
+        )
+
+    @patch("news_articles.services.openai_llm_service.openai.Completion.create")
+    def test_get_confidence_score_error_handling(self, mock_create):
+        mock_create.side_effect = Exception("API error")
+
+        article_text = "This is a test article text."
+        score = self.service.get_confidence_score(article_text)
+
+        self.assertIsNone(score)

--- a/ipno/news_articles/views.py
+++ b/ipno/news_articles/views.py
@@ -12,6 +12,7 @@ from news_articles.documents import NewsArticleESDoc
 from news_articles.models import NewsArticle
 from shared.serializers import NewsArticleSerializer
 from utils.cache_utils import flush_news_article_related_caches
+from news_articles.services.openai_llm_service import OpenAILLMService
 
 
 class NewsArticlesViewSet(viewsets.ViewSet):


### PR DESCRIPTION
Use OpenAI LLM API integration to process news articles and return confidence scores for police misconduct detection.

* **New Service**: Add `openai_llm_service.py` to interact with OpenAI LLM APIs, including a function to send news article text and receive confidence scores.
* **Article Classification Importer**: Update `article_classification_importer.py` to call the new OpenAI LLM service and store the confidence score for each news article.
* **News Articles View**: Update `views.py` to import the new OpenAI LLM service.
* **Tests**: Add `test_openai_llm_service.py` to test the new OpenAI LLM service, including tests for sending news article text, receiving confidence scores, and error handling.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PublicDataWorks/llead-backend?shareId=9da0da1e-59a8-409e-b930-9bc19e0b4ca4).